### PR TITLE
Associate function pointer lifetimes with the database

### DIFF
--- a/src/wrapper/connection.ml
+++ b/src/wrapper/connection.ml
@@ -1,25 +1,32 @@
 open! Core
 open! Ctypes
 
-type t = Duckdb_stubs.Connection.t ptr Resource.t
+type t =
+  { connection : Duckdb_stubs.Connection.t ptr Resource.t
+  ; database : Database.t
+  }
 
 let connect_exn db =
-  let db = Database.Private.to_ptr db |> Resource.get_exn in
+  let db' = Database.Private.to_ptr db |> Resource.get_exn in
   let t =
     allocate Duckdb_stubs.Connection.t (from_voidp Duckdb_stubs.Connection.t_struct null)
   in
-  match Duckdb_stubs.duckdb_connect !@db t with
+  match Duckdb_stubs.duckdb_connect !@db' t with
   | DuckDBSuccess ->
-    Resource.create t ~name:"Duckdb.Connection" ~free:Duckdb_stubs.duckdb_disconnect
+    { connection =
+        Resource.create t ~name:"Duckdb.Connection" ~free:Duckdb_stubs.duckdb_disconnect
+    ; database = db
+    }
   | DuckDBError -> failwith "Failed to connect to database"
 ;;
 
-let disconnect = Resource.free
+let disconnect { connection; database = _ } = Resource.free connection
 
 let with_connection db ~f =
   connect_exn db |> Exn.protectx ~f ~finally:(disconnect ~here:[%here])
 ;;
 
 module Private = struct
-  let to_ptr = Fn.id
+  let to_ptr { connection; database = _ } = connection
+  let database { connection = _; database } = database
 end

--- a/src/wrapper/connection.mli
+++ b/src/wrapper/connection.mli
@@ -8,4 +8,5 @@ val with_connection : Database.t -> f:(t -> 'a) -> 'a
 
 module Private : sig
   val to_ptr : t -> Duckdb_stubs.Connection.t Ctypes.ptr Resource.t
+  val database : t -> Database.t
 end

--- a/src/wrapper/database.mli
+++ b/src/wrapper/database.mli
@@ -8,4 +8,5 @@ val with_path : string -> f:(t -> 'a) -> 'a
 
 module Private : sig
   val to_ptr : t -> Duckdb_stubs.Database.t Ctypes.ptr Resource.t
+  val add_closure_root : 'a Resource.t -> t -> unit
 end

--- a/src/wrapper/scalar_function.mli
+++ b/src/wrapper/scalar_function.mli
@@ -6,13 +6,10 @@ module Signature : sig
     | ( :: ) : 'a Type.Typed_non_null.t * ('b, 'ret) t -> ('a -> 'b, 'ret) t
 end
 
-type t
-
-val create : string -> ('f, 'ret) Signature.t -> f:'f -> t
-val register_exn : t -> Connection.t -> unit
+val create_exn : string -> ('f, 'ret) Signature.t -> f:'f -> conn:Connection.t -> unit
 
 module Expert : sig
-  val create
+  val create_exn
     :  string
     -> Type.t list
     -> f:
@@ -20,5 +17,6 @@ module Expert : sig
           -> Duckdb_stubs.Data_chunk.t
           -> Duckdb_stubs.Vector.t
           -> unit)
-    -> t
+    -> conn:Connection.t
+    -> unit
 end

--- a/test/duckdb_test.ml
+++ b/test/duckdb_test.ml
@@ -321,6 +321,8 @@ let%expect_test "replacement scan" =
 let%expect_test "table function registration" =
   Duckdb.Database.with_path ":memory:" ~f:(fun db ->
     Duckdb.Connection.with_connection db ~f:(fun conn ->
+      (* Set DuckDB to single-threaded mode to avoid thread safety issues *)
+      Single_thread_fix.set_single_threaded conn;
       let size = ref 0 in
       let pos = ref 0 in
       Duckdb.Table_function.add
@@ -396,6 +398,8 @@ let%expect_test "table function registration" =
         |}]);
     (* Table function persists across connections *)
     Duckdb.Connection.with_connection db ~f:(fun conn ->
+      (* Set DuckDB to single-threaded mode to avoid thread safety issues *)
+      Single_thread_fix.set_single_threaded conn;
       Duckdb.Query.run_exn conn "SELECT * FROM my_function(1)" ~f:print_result;
       [%expect
         {|


### PR DESCRIPTION
I believe this was another source of segfaults when garbage collections eagerly collected function pointers which were still alive since the database was still open.